### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_sentry"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 description = "Sentry reporting plugin for Bevy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_sentry"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 description = "Sentry reporting plugin for Bevy"


### PR DESCRIPTION



## 🤖 New release

* `vleue_sentry`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).